### PR TITLE
 # EDIT - HmacKeyMaker curve

### DIFF
--- a/src/hmac_key_maker.hpp
+++ b/src/hmac_key_maker.hpp
@@ -19,7 +19,7 @@ using namespace std;
 class HmacKeyMaker {
 public:
   HmacKeyMaker()
-      : group_domain{"secp256r1"}, kdf{"Raw"}, curve{Botan::CurveGFp(group_domain.get_p(), group_domain.get_a(), group_domain.get_b())} {}
+      : group_domain{"secp256k1"}, kdf{"Raw"}, curve{Botan::CurveGFp(group_domain.get_p(), group_domain.get_a(), group_domain.get_b())} {}
 
   pair<string, string> getPublicKey() {
     generateRandomSecretKey();


### PR DESCRIPTION
- secp256r1 -> secp256k1

https://thevaulters.atlassian.net/wiki/spaces/SGN/pages/110428161/A3.+secp256r1+vs+secp256k1
(ECDH key ex 중 signer 는 현재 secp256k1 사용 중)